### PR TITLE
Log port when starting the server.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules/
 npm-debug.log
 data/
 
+#Igno IntellIJ IDEs (like WebStorm and PyCharm) configuration:
+.idea
+

--- a/bin/www
+++ b/bin/www
@@ -3,6 +3,7 @@ var debug = require('debug')('storming');
 var app = require('../app');
 
 app.set('port', process.env.PORT || 3000);
+console.log('Starting server on port '+app.get('port'))
 
 var server = app.listen(app.get('port'), function() {
   debug('Express server listening on port ' + server.address().port);


### PR DESCRIPTION
This will make it easier to find out how to open the app in your browser.
