### PR TITLE
Fix for bounty #85: [Bug] Wrong tweet text when sharing existing post

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ var Constants = {
   MongoURL: "mongodb://localhost/local",
   RedisURL: "redis://localhost:6379"
 };
+
+modules.exports = Constants;
 ```
 
 Things you need to do:

--- a/public/js/postscripter.js
+++ b/public/js/postscripter.js
@@ -2,9 +2,9 @@ $(document).ready(function() {
   $('.sharepost').click(function() {
     $('.sharepost').text('Sharing Post...');
     draw();
-    var author_name = $('#author_name').text()
-    var url = document.URL
-    var message = "Check out this post by @"+author_name+" "+url;
+    var author_name = $('.author-name').first().text();
+    var url = document.URL;
+    var message = "Check out this post by @"+author_name+" sent via @Squallapp "+url;
 
     $.post('/tweet', { image: $('#image').attr('src'), message: message }, function(data) {
       $('.sharepost').text('Tweeted!');


### PR DESCRIPTION
Also a quick note in README for those who just copy/pasted the example `constant.js` file shown in the readme. Y'know, to make it easier for folks to jump right in like me!

Looks like the markup got changed at some point so the author name was being pulled from somewhere that didn't exist. Drawing this data from the markup is silly and we should have the backend detect which tweet is being shared and then extract the username from our database. This is the ideal solution. 
