### PR TITLE
Fix tweet length counter

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -45,7 +45,7 @@ var editor = new MediumEditor('.editable', {
 function draw(callback) {
   console.log('draw(callback) ');
   $('#image-header-title').text($('#textArea').val());
-  
+
   //TODO include moment.js for datetime
   //TODO make sure user time is correctish by using server time
   var temp_d = new Date();
@@ -64,13 +64,13 @@ function draw(callback) {
 	      document.getElementById('image').src = canvas.toDataURL();
 	      $('#image-container').css('display','none');
 	      if(callback){
-	    	  callback();  
+	    	  callback();
 	    	  console.log('callback called');
 	      }
 	      else{
 	    	  console.log('no callback ');
 	      }
-          
+  
 	    }
 	  });
     }
@@ -111,7 +111,7 @@ $(document).ready(function() {
 //  });
 
   $('.tweet-button').click(function() {
-	
+
 	draw(function(){
 		toggler(function() {
 	      $('.tweet-button').text('Tweet Posted');
@@ -138,13 +138,13 @@ $(document).ready(function() {
 	      });
 	    });
 	});
-    
+
 
   });
 
 
   $('.upload-imgur').click(function() {
-	  
+
 	draw( function(){
 		$('.tweet-button').text('Uploading image...');
 	    $('.tweetresult').css('display', 'none');
@@ -165,7 +165,7 @@ $(document).ready(function() {
 	      $('.tweet-button').removeClass('disabled');
 	    });
 	});
-	
+
   });
 
 
@@ -195,7 +195,7 @@ $('#textArea').keyup(function() {
   var text = $(this).val();
   var splits = text.split(' ');
   geturl = new RegExp("(^|[ \t\r\n])((ftp|http|https|gopher|mailto|news|nntp|telnet|wais|file|prospero|aim|webcal):(([A-Za-z0-9$_.+!*(),;/?:@&~=-])|%[A-Fa-f0-9]{2}){2,}(#([a-zA-Z0-9][a-zA-Z0-9$_.+!*(),;/?:@&~=%-]*))?([A-Za-z0-9$_+!*();/?:~-]))", "g");
-  var length = 0;
+  var length = (text.match(/ /g) || []).length;
 
   for (var i = 0; i < splits.length; i++) {
     if (splits[i].match(geturl) && splits[i].length > TCO_LENGTH) {
@@ -278,7 +278,7 @@ $('.unfollowuser').click(function() {
     $('#success-alert').addClass("hide");
     $('#error-alert').addClass("hide");
     var params = $('#settings-form').serializeJSON();
-    
+
     $.post('/settings', params, function(data) {
       if (data.passed) {
         $('#success-alert').removeClass("hide");
@@ -289,8 +289,8 @@ $('.unfollowuser').click(function() {
     });
     e.preventDefault();
   });
-  
-  
+
+
   //getting avatar uri by ajax
   //TODO handle errors in AJAX
   $.ajax('./avatar_uri').done(function(data){
@@ -299,7 +299,7 @@ $('.unfollowuser').click(function() {
   // filling the header of the image to be tweeted, fixing issues of floats
   var image_header_name = $('#image-header-name');
   image_header_name.html(image_header_name.text().replace(/ /g,'&nbsp;'));
-  
+
 })
 
 function toggler(callback) {


### PR DESCRIPTION
This fixes the tweet text counter (bounty 92).

Splitting the tweet text at the whitespace removes the whitespaces from the length calculation. This commit fixes this.
